### PR TITLE
Fixed caddy reverse proxy for gRPC

### DIFF
--- a/Trojan-gRPC-Caddy2／Nginx/Caddyfile
+++ b/Trojan-gRPC-Caddy2／Nginx/Caddyfile
@@ -3,7 +3,7 @@ example.com {
 		protocol grpc
 		path  # 填写 /你的 ServiceName/*
 	}
-    reverse_proxy @grpc unix//dev/shm/Xray-Trojan-gRPC.socket {
+	reverse_proxy @grpc unix//dev/shm/Xray-Trojan-gRPC.socket {
 		transport http {
 			versions h2c
 		}

--- a/VLESS-GRPC/Caddyfile
+++ b/VLESS-GRPC/Caddyfile
@@ -3,7 +3,7 @@ xx.com {
 		protocol grpc
 		path  # 填写 /你的 ServiceName/*
 	}
-    reverse_proxy @grpc unix//dev/shm/Xray-Trojan-gRPC.socket {
+	reverse_proxy @grpc unix//dev/shm/Xray-Trojan-gRPC.socket {
 		transport http {
 			versions h2c
 		}


### PR DESCRIPTION
Hello
There was a bug in Caddy reverse proxying gRPC. It must be specified to use HTTP2 overwise it won't work at all. I just changed the Caddyfiles and specified HTTP2 over clear text in them.
I also changed them to use tab instead of space because Caddy formats them with tab :)
At last I should say that I tested this config behind Cloudflare's CDN and it's working fine.

PS: This pull request might fix #79 