### PR TITLE
VLESS-GRPC add multiMode field

### DIFF
--- a/VLESS-GRPC/client.json
+++ b/VLESS-GRPC/client.json
@@ -37,6 +37,7 @@
         "security": "tls",
         "grpcSettings": {
           "serviceName": "", //填写你的 ServiceName
+          "multiMode": false,
           //"idle_timeout": 60, //当这段时间内没有数据传输时，将会进行健康检查。可能会解决一些“断流”问题。
           //"initial_windows_size": 35536 //通过 Cloudflare CDN 时，防止 Cloudflare CDN 发送意外的 h2 GOAWAY 帧以关闭现有连接。
         }


### PR DESCRIPTION
@xqzr Enable VLESS GRPC in Xray-core v1.6.5 seems to have to pass the multi Mode field, otherwise the connection will fail, refer to the link <https://xtls.github.io/config/transports/grpc.html#grpcobject>