### PR TITLE
Fix port datatype in VLESS-mKCPSeed

### DIFF
--- a/VLESS-mKCPSeed/config_client.json
+++ b/VLESS-mKCPSeed/config_client.json
@@ -19,7 +19,7 @@
                 "vnext": [
                     {
                         "address": "{{ host }}",
-                        "port": "{{ port }}",
+                        "port": {{ port }},
                         "users": [
                             {
                                 "id": "{{ uuid }}",


### PR DESCRIPTION
I tried to set the port as a string, but Xray can't parse such config. So I changed it to a number.