### PR TITLE
Fix caddy reverse proxy latency

### DIFF
--- a/VLESS-GRPC/Caddyfile
+++ b/VLESS-GRPC/Caddyfile
@@ -4,6 +4,7 @@ xx.com {
 		path /ServiceName/* # 修改为你自己的 ServiceName，且仅能存在两个斜杠。（如：/MyService/ServiceName/*会导致错误）
 	}
 	reverse_proxy @grpc unix//dev/shm/Xray-VLESS-gRPC.socket {
+		flush_interval -1
 		transport http {
 			versions h2c
 		}


### PR DESCRIPTION
Add "flush_interval -1" to disable caddy reverse proxy buffer.
See [https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#streaming](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#streaming)