### PR TITLE
Serverless-for-Iran: fixing some issues about UDP routing and noise

### DIFF
--- a/Serverless-for-Iran/serverless_for_Iran.jsonc
+++ b/Serverless-for-Iran/serverless_for_Iran.jsonc
@@ -135,7 +135,7 @@
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
-          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"}
+          {"type": "rand", "packet": "1250", "delay": "10"}
         ]
       }            
     },
@@ -156,7 +156,7 @@
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
-          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"}
+          {"type": "rand", "packet": "1230", "delay": "10"}
         ]
       }            
     }          

--- a/Serverless-for-Iran/serverless_for_Iran.jsonc
+++ b/Serverless-for-Iran/serverless_for_Iran.jsonc
@@ -135,8 +135,7 @@
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
-          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
-          {"type": "rand", "packet": "1250", "delay": "10"}
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"}
         ]
       }            
     },
@@ -157,8 +156,7 @@
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
-          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
-          {"type": "rand", "packet": "1230", "delay": "10"}
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"}
         ]
       }            
     }          

--- a/Serverless-for-Iran/serverless_for_Iran.jsonc
+++ b/Serverless-for-Iran/serverless_for_Iran.jsonc
@@ -1,7 +1,7 @@
 // Configs here can not contain "bypassing sanctions" contents (inappropriate on US GitHub)
 // Please join the official Xray Iranian group https://t.me/projectXhttp to get the whole working configs
 
-// Serverless for Iran v1
+// Serverless for Iran v2
 // Xray-core v25.2.21+
 
 // Bypass censorship using TCP/TLS fragment and UDP noises.
@@ -42,7 +42,7 @@
       "protocol": "socks",
       "sniffing": {
         "enabled": true,
-        "destOverride": ["http", "tls", "quic"],
+        "destOverride": ["http", "tls"],
         "routeOnly": false
       },
       "settings": {"udp": true}
@@ -119,24 +119,46 @@
       }
     },
     {
-      "tag": "udp-noises",
+      "tag": "udp-noisesv4",
       "protocol": "freedom",
       "settings": {
-        "domainStrategy": "ForceIP",
+        "domainStrategy": "ForceIPv4",
         "noises": [
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "10"}
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}
+        ]
+      }            
+    },
+    {
+      "tag": "udp-noisesv6",
+      "protocol": "freedom",
+      "settings": {
+        "domainStrategy": "ForceIPv6",
+        "noises": [
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}
         ]
       }            
     }          
@@ -158,7 +180,7 @@
        "domain": ["geosite:category-ads-all"]
       },
       {"outboundTag": "block",
-       "ip": ["10.10.34.0/24", "2001:4188:2:600:10:10:34:36", "2001:4188:2:600:10:10:34:35"]
+       "ip": ["10.10.34.0/24", "2001:4188:2:600:10:10:34:36", "2001:4188:2:600:10:10:34:35", "2001:4188:2:600:10:10:34:34"]
       },           
       {"outboundTag": "direct",
        "domain": ["geosite:private", "geosite:category-ir"]
@@ -166,7 +188,13 @@
       {"outboundTag": "direct",
        "ip": ["geoip:private", "geoip:ir"]
       },                                                         	                                                        
-      {"outboundTag": "udp-noises",
+      {"outboundTag": "udp-noisesv4",
+       "network": "udp", "ip": ["0.0.0.0/0"], "port": 443
+      },
+      {"outboundTag": "udp-noisesv6",
+       "network": "udp", "ip": ["::/0"], "port": 443
+      },
+      {"outboundTag": "direct",
        "network": "udp"
       },
       {"outboundTag": "chain1-fragment",  // or "super-fragment"

--- a/Serverless-for-Iran/serverless_with_mitm_for_Iran.jsonc
+++ b/Serverless-for-Iran/serverless_with_mitm_for_Iran.jsonc
@@ -251,8 +251,7 @@
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
-          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
-          {"type": "rand", "packet": "1250", "delay": "10"}
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"}
         ]
       }            
     },
@@ -273,8 +272,7 @@
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
-          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
-          {"type": "rand", "packet": "1230", "delay": "10"}
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"}
         ]
       }            
     }          

--- a/Serverless-for-Iran/serverless_with_mitm_for_Iran.jsonc
+++ b/Serverless-for-Iran/serverless_with_mitm_for_Iran.jsonc
@@ -251,7 +251,7 @@
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
           {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
-          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"}
+          {"type": "rand", "packet": "1250", "delay": "10"}
         ]
       }            
     },
@@ -272,7 +272,7 @@
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
           {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
-          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"}
+          {"type": "rand", "packet": "1230", "delay": "10"}
         ]
       }            
     }          

--- a/Serverless-for-Iran/serverless_with_mitm_for_Iran.jsonc
+++ b/Serverless-for-Iran/serverless_with_mitm_for_Iran.jsonc
@@ -1,7 +1,7 @@
 // Configs here can not contain "bypassing sanctions" contents (inappropriate on US GitHub)
 // Please join the official Xray Iranian group https://t.me/projectXhttp to get the whole working configs
 
-// Serverless with MitM-Domain-Fronting for Iran v1
+// Serverless with MitM-Domain-Fronting for Iran v2
 // Xray-core v25.2.21+
 
 // Requires a self-signed-certificate: You can create it using "./xray tls cert -ca -file=mycert" command.
@@ -42,7 +42,7 @@
       "protocol": "socks",
       "sniffing": {
         "enabled": true,
-        "destOverride": ["http", "tls", "quic"],
+        "destOverride": ["http", "tls"],
         "routeOnly": false
       },
       "settings": {"udp": true}
@@ -235,24 +235,46 @@
       }
     },
     {
-      "tag": "udp-noises",
+      "tag": "udp-noisesv4",
       "protocol": "freedom",
       "settings": {
-        "domainStrategy": "ForceIP",
+        "domainStrategy": "ForceIPv4",
         "noises": [
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "1"},
-          {"type": "rand", "packet": "257-507", "delay": "1"}, {"type": "rand", "packet": "257-507", "delay": "10"}
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}, {"type": "rand", "packet": "1250", "delay": "10"},
+          {"type": "rand", "packet": "1250", "delay": "10"}
+        ]
+      }            
+    },
+    {
+      "tag": "udp-noisesv6",
+      "protocol": "freedom",
+      "settings": {
+        "domainStrategy": "ForceIPv6",
+        "noises": [
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}, {"type": "rand", "packet": "1230", "delay": "10"},
+          {"type": "rand", "packet": "1230", "delay": "10"}
         ]
       }            
     }          
@@ -274,7 +296,7 @@
        "domain": ["geosite:category-ads-all"]
       },
       {"outboundTag": "block",
-       "ip": ["10.10.34.0/24", "2001:4188:2:600:10:10:34:36", "2001:4188:2:600:10:10:34:35"]
+       "ip": ["10.10.34.0/24", "2001:4188:2:600:10:10:34:36", "2001:4188:2:600:10:10:34:35", "2001:4188:2:600:10:10:34:34"]
       },           
       {"outboundTag": "direct",
        "domain": ["geosite:private", "geosite:category-ir"]
@@ -315,7 +337,13 @@
        "domain": ["geosite:x", "geosite:reddit"],
        "inboundTag": ["tls-decrypt-h11", "tls-decrypt-h211"]
       },                                                         	                                                        
-      {"outboundTag": "udp-noises",
+      {"outboundTag": "udp-noisesv4",
+       "network": "udp", "ip": ["0.0.0.0/0"], "port": 443
+      },
+      {"outboundTag": "udp-noisesv6",
+       "network": "udp", "ip": ["::/0"], "port": 443
+      },
+      {"outboundTag": "direct",
        "network": "udp"
       },
       {"outboundTag": "chain1-fragment",  // or "super-fragment"


### PR DESCRIPTION
sniffing "quic" had caused some problems(disabled multi-ip retry on browsers[happy-eyeballs])
also, the noise parameters were optimized for ipv4 and ipv6 separately.
and add "2001:4188:2:600:10:10:34:34" (an ip that GFW returned for blocked sites) to blocked IPs.
and change the version to 2.