### PR TITLE
Serverless-for-Iran: Change domain-fronting fake-sni for visiting 1.1.1.1

### DIFF
--- a/Serverless-for-Iran/serverless_for_Iran.jsonc
+++ b/Serverless-for-Iran/serverless_for_Iran.jsonc
@@ -1,7 +1,7 @@
 // Configs here can not contain "bypassing sanctions" contents (inappropriate on US GitHub)
 // Please join the official Xray Iranian group https://t.me/projectXhttp to get the whole working configs
 
-// Serverless for Iran v3
+// Serverless for Iran v4
 // Xray-core v25.2.21+
 
 // Bypass censorship using TCP/TLS fragment and UDP noises.

--- a/Serverless-for-Iran/serverless_with_mitm_for_Iran.jsonc
+++ b/Serverless-for-Iran/serverless_with_mitm_for_Iran.jsonc
@@ -1,7 +1,7 @@
 // Configs here can not contain "bypassing sanctions" contents (inappropriate on US GitHub)
 // Please join the official Xray Iranian group https://t.me/projectXhttp to get the whole working configs
 
-// Serverless with MitM-Domain-Fronting for Iran v3
+// Serverless with MitM-Domain-Fronting for Iran v4
 // Xray-core v25.2.21+
 
 // Requires a self-signed-certificate: You can create it using "./xray tls cert -ca -file=mycert" command.
@@ -126,8 +126,8 @@
       "streamSettings": {      
         "security": "tls",
         "tlsSettings": {
-          "serverName": "www.bing.com",
-          "verifyPeerCertInNames": ["fromMitM", "www.bing.com"],
+          "serverName": "www.microsoft.com",
+          "verifyPeerCertInNames": ["fromMitM", "www.microsoft.com"],
           "alpn": ["fromMitM"],
           "fingerprint": "chrome"
         }


### PR DESCRIPTION
the MitM config use h2c://1.1.1.1/dns-query

for using domain-fronting for the IP: 1.1.1.1, our fake-sni should not be behind cloudflare.

(most cloudflare IPs doesn't allow domain-fronting at all, but some of them allow, like cloudflare-DNS IPs, but the fake-sni should not be behind cloudflare)

I used to use "www.bing.com" but recently the "www.bing.com" domain went behind cloudflare (When you make a TLS request with sni "www.bing.com" to 1.1.1.1, the certificate that is returned is the "www.bing.com" certificate, indicating that Bing is registered in Cloudflare)

so the domain-fronting doesn't work for it and as a result, the configuration was not usable.

so i change it to another whitelist-sni that is not behind cloudflare: "www.microsoft.com".
