### PR TITLE
简化VLESS和Vmess的客户端配置

### DIFF
--- a/All-in-One-fallbacks-Nginx/client.configs/VMESS-H2-TLS.jsonc
+++ b/All-in-One-fallbacks-Nginx/client.configs/VMESS-H2-TLS.jsonc
@@ -16,19 +16,10 @@
     {
       "protocol": "vmess",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
-                "alterId": 0,
-                "security": "none"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
+        "security": "none"
       },
       "streamSettings": {
         "network": "http",

--- a/All-in-One-fallbacks-Nginx/client.configs/VMESS-TCP-TLS.jsonc
+++ b/All-in-One-fallbacks-Nginx/client.configs/VMESS-TCP-TLS.jsonc
@@ -16,19 +16,10 @@
     {
       "protocol": "vmess",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
-                "alterId": 0,
-                "security": "none"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
+        "security": "none"
       },
       "streamSettings": {
         "network": "tcp",

--- a/All-in-One-fallbacks-Nginx/client.configs/VMESS-WS-TLS.jsonc
+++ b/All-in-One-fallbacks-Nginx/client.configs/VMESS-WS-TLS.jsonc
@@ -16,19 +16,10 @@
     {
       "protocol": "vmess",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
-                "alterId": 0,
-                "security": "none"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
+        "security": "none"
       },
       "streamSettings": {
         "network": "ws",

--- a/All-in-One-fallbacks-Nginx/client.configs/VMESS-gRPC-TLS.jsonc
+++ b/All-in-One-fallbacks-Nginx/client.configs/VMESS-gRPC-TLS.jsonc
@@ -16,19 +16,10 @@
     {
       "protocol": "vmess",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
-                "alterId": 0,
-                "security": "none"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
+        "security": "none"
       },
       "streamSettings": {
         "network": "grpc",

--- a/All-in-One-fallbacks-Nginx/client.configs/Vless-H2-TLS.jsonc
+++ b/All-in-One-fallbacks-Nginx/client.configs/Vless-H2-TLS.jsonc
@@ -16,18 +16,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "http",

--- a/All-in-One-fallbacks-Nginx/client.configs/Vless-TCP-TLS.jsonc
+++ b/All-in-One-fallbacks-Nginx/client.configs/Vless-TCP-TLS.jsonc
@@ -16,18 +16,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "tcp",

--- a/All-in-One-fallbacks-Nginx/client.configs/Vless-TCP-XTLS.jsonc
+++ b/All-in-One-fallbacks-Nginx/client.configs/Vless-TCP-XTLS.jsonc
@@ -16,19 +16,11 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
-                "encryption": "none",
-                "flow": "xtls-rprx-vision"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
+        "encryption": "none",
+        "flow": "xtls-rprx-vision"
       },
       "streamSettings": {
         "network": "tcp",

--- a/All-in-One-fallbacks-Nginx/client.configs/Vless-WS-TLS.jsonc
+++ b/All-in-One-fallbacks-Nginx/client.configs/Vless-WS-TLS.jsonc
@@ -16,18 +16,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "ws",

--- a/All-in-One-fallbacks-Nginx/client.configs/Vless-gRPC-TLS.jsonc
+++ b/All-in-One-fallbacks-Nginx/client.configs/Vless-gRPC-TLS.jsonc
@@ -16,18 +16,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "90e4903e-66a4-45f7-abda-fd5d5ed7f797",
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "grpc",

--- a/ReverseProxy/VLESS-TCP-XTLS-WS/bridge.jsonc
+++ b/ReverseProxy/VLESS-TCP-XTLS-WS/bridge.jsonc
@@ -15,19 +15,11 @@
       "tag": "interconn",
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "reverse.example", // 换成你的域名或 IP
-            "port": 443,
-            "users": [
-              {
-                "id": "", // 填写你的 UUID
-                "encryption": "none",
-                "level": 0
-              }
-            ]
-          }
-        ]
+        "address": "reverse.example", // 换成你的域名或 IP
+        "port": 443,
+        "id": "", // 填写你的 UUID
+        "encryption": "none",
+        "level": 0
       },
       "streamSettings": {
         "network": "ws",

--- a/ReverseProxy/VLESS-TCP-XTLS-WS/client_tcp.jsonc
+++ b/ReverseProxy/VLESS-TCP-XTLS-WS/client_tcp.jsonc
@@ -33,20 +33,12 @@
       "tag": "proxy",
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "reverse.example", // 换成你的域名或服务器 IP
-            "port": 443,
-            "users": [
-              {
-                "id": "", // 填写你的 UUID
-                "flow": "xtls-rprx-vision",
-                "encryption": "none",
-                "level": 0
-              }
-            ]
-          }
-        ]
+        "address": "reverse.example", // 换成你的域名或服务器 IP
+        "port": 443,
+        "id": "", // 填写你的 UUID
+        "flow": "xtls-rprx-vision",
+        "encryption": "none",
+        "level": 0
       },
       "streamSettings": {
         "network": "tcp",

--- a/ReverseProxy/VLESS-TCP-XTLS-WS/client_ws.jsonc
+++ b/ReverseProxy/VLESS-TCP-XTLS-WS/client_ws.jsonc
@@ -33,19 +33,11 @@
       "tag": "proxy",
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "reverse.example", // 换成你的域名或服务器 IP
-            "port": 443,
-            "users": [
-              {
-                "id": "", // 填写你的 UUID
-                "encryption": "none",
-                "level": 0
-              }
-            ]
-          }
-        ]
+        "address": "reverse.example", // 换成你的域名或服务器 IP
+        "port": 443,
+        "id": "", // 填写你的 UUID
+        "encryption": "none",
+        "level": 0
       },
       "streamSettings": {
         "network": "ws",

--- a/ReverseProxy/Vmess-TCP/bridge.jsonc
+++ b/ReverseProxy/Vmess-TCP/bridge.jsonc
@@ -15,17 +15,9 @@
       "tag": "interconn",
       "protocol": "vmess",
       "settings": {
-        "vnext": [
-          {
-            "address": "{{ protal.address }}",
-            "port": 65510,
-            "users": [
-              {
-                "id": "{{ uuid }}"
-              }
-            ]
-          }
-        ]
+        "address": "{{ protal.address }}",
+        "port": 65510,
+        "id": "{{ uuid }}"
       },
       "streamSettings": {
         "network": "tcp"

--- a/ReverseProxy/Vmess-TCP/client.jsonc
+++ b/ReverseProxy/Vmess-TCP/client.jsonc
@@ -32,17 +32,9 @@
         {
             "protocol": "vmess",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "{{ protal.address }}",
-                        "port": 65511,
-                        "users": [
-                            {
-                                "id": "{{ uuid }}"
-                            }
-                        ]
-                    }
-                ]
+                "address": "{{ protal.address }}",
+                "port": 65511,
+                "id": "{{ uuid }}"
             },
             "streamSettings": {
                 "network": "tcp"

--- a/VLESS-GRPC/client.jsonc
+++ b/VLESS-GRPC/client.jsonc
@@ -19,18 +19,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "xx.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "", //填写你的 UUID
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "xx.com",
+        "port": 443,
+        "id": "", //填写你的 UUID
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "grpc",

--- a/VLESS-HTTP-Caddy/VLESS-H2C-Caddy/client.jsonc
+++ b/VLESS-HTTP-Caddy/VLESS-H2C-Caddy/client.jsonc
@@ -19,18 +19,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "xx.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "",
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "xx.com",
+        "port": 443,
+        "id": "",
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "h2",

--- a/VLESS-HTTP-Caddy/VLESS-H3-Caddy/client.jsonc
+++ b/VLESS-HTTP-Caddy/VLESS-H3-Caddy/client.jsonc
@@ -19,18 +19,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "xx.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "",
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "xx.com",
+        "port": 443,
+        "id": "",
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "http",

--- a/VLESS-HTTP-Caddy/VLESS-H3-To-H2C-Caddy/client.jsonc
+++ b/VLESS-HTTP-Caddy/VLESS-H3-To-H2C-Caddy/client.jsonc
@@ -19,18 +19,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "xx.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "",
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "xx.com",
+        "port": 443,
+        "id": "",
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "http",

--- a/VLESS-TCP-REALITY (without being stolen)/config_client.jsonc
+++ b/VLESS-TCP-REALITY (without being stolen)/config_client.jsonc
@@ -26,18 +26,10 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "127.0.0.1", 
-                        "port": 443, 
-                        "users": [
-                            {
-                                "id": "", // Needs to match server side
-                                "encryption": "none"
-                            }
-                        ]
-                    }
-                ]
+                "address": "127.0.0.1",
+                "port": 443,
+                "id": "", // Needs to match server side
+                "encryption": "none"
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VLESS-TCP-TLS (maximal by rprx)/config_client.jsonc
+++ b/VLESS-TCP-TLS (maximal by rprx)/config_client.jsonc
@@ -16,19 +16,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "example.com", // 换成你的域名或服务器 IP（发起请求时无需解析域名了）
-                        "port": 443,
-                        "users": [
-                            {
-                                "id": "", // 填写你的 UUID
-                                "encryption": "none",
-                                "level": 0
-                            }
-                        ]
-                    }
-                ]
+                "address": "example.com", // 换成你的域名或服务器 IP（发起请求时无需解析域名了）
+                "port": 443,
+                "id": "", // 填写你的 UUID
+                "encryption": "none",
+                "level": 0
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VLESS-TCP-TLS (minimal by rprx)/config_client.jsonc
+++ b/VLESS-TCP-TLS (minimal by rprx)/config_client.jsonc
@@ -16,19 +16,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "example.com", // 换成你的域名
-                        "port": 443,
-                        "users": [
-                            {
-                                "id": "", // 填写你的 UUID
-                                "encryption": "none",
-                                "level": 0
-                            }
-                        ]
-                    }
-                ]
+                "address": "example.com", // 换成你的域名
+                "port": 443,
+                "id": "", // 填写你的 UUID
+                "encryption": "none",
+                "level": 0
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VLESS-TCP-TLS-WS/config_client_tcp_tls.jsonc
+++ b/VLESS-TCP-TLS-WS/config_client_tcp_tls.jsonc
@@ -16,19 +16,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "example.com", // 换成你的域名或服务器 IP（发起请求时无需解析域名了）
-                        "port": 443,
-                        "users": [
-                            {
-                                "id": "", // 填写你的 UUID
-                                "encryption": "none",
-                                "level": 0
-                            }
-                        ]
-                    }
-                ]
+                "address": "example.com", // 换成你的域名或服务器 IP（发起请求时无需解析域名了）
+                "port": 443,
+                "id": "", // 填写你的 UUID
+                "encryption": "none",
+                "level": 0
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VLESS-TCP-TLS-WS/config_client_ws_tls.jsonc
+++ b/VLESS-TCP-TLS-WS/config_client_ws_tls.jsonc
@@ -16,19 +16,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "example.com", // 换成你的域名或服务器 IP（发起请求时无需解析域名了）
-                        "port": 443,
-                        "users": [
-                            {
-                                "id": "", // 填写你的 UUID
-                                "encryption": "none",
-                                "level": 0
-                            }
-                        ]
-                    }
-                ]
+                "address": "example.com", // 换成你的域名或服务器 IP（发起请求时无需解析域名了）
+                "port": 443,
+                "id": "", // 填写你的 UUID
+                "encryption": "none",
+                "level": 0
             },
             "streamSettings": {
                 "network": "ws",

--- a/VLESS-TCP-TLS-proxy protocol/config_client.jsonc
+++ b/VLESS-TCP-TLS-proxy protocol/config_client.jsonc
@@ -23,19 +23,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "1.2.3.4",
-                        "port": 443,
-                        "user": [
-                            {
-                                "id": "",
-                                "encryption": "none",
-                                "level": 0
-                            }
-                        ]
-                    }
-                ]
+                "address": "1.2.3.4",
+                "port": 443,
+                "id": "",
+                "encryption": "none",
+                "level": 0
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VLESS-TCP-TLS/config_client.jsonc
+++ b/VLESS-TCP-TLS/config_client.jsonc
@@ -23,19 +23,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "1.2.3.4",
-                        "port": 443,
-                        "users": [
-                            {
-                                "id": "",
-                                "encryption": "none",
-                                "level": 0
-                            }
-                        ]
-                    }
-                ]
+                "address": "1.2.3.4",
+                "port": 443,
+                "id": "",
+                "encryption": "none",
+                "level": 0
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VLESS-TCP-XTLS-Vision-REALITY/REALITY.ENG.md
+++ b/VLESS-TCP-XTLS-Vision-REALITY/REALITY.ENG.md
@@ -59,19 +59,11 @@ Typical use cases for proxying involve minimum requirements for target websites:
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "", // Server's domain or IP
-                        "port": 443,
-                        "users": [
-                            {
-                                "id": "", // Matching the server-side
-                                "flow": "xtls-rprx-vision", // Matching the server-side
-                                "encryption": "none"
-                            }
-                        ]
-                    }
-                ]
+                "address": "", // Server's domain or IP
+                "port": 443,
+                "id": "", // Matching the server-side
+                "flow": "xtls-rprx-vision", // Matching the server-side
+                "encryption": "none"
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VLESS-TCP-XTLS-Vision-REALITY/config_client.jsonc
+++ b/VLESS-TCP-XTLS-Vision-REALITY/config_client.jsonc
@@ -25,19 +25,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "", 
-                        "port": 443, 
-                        "users": [
-                            {
-                                "id": "", // Needs to match server side
-                                "encryption": "none",
-                                "flow": "xtls-rprx-vision"
-                            }
-                        ]
-                    }
-                ]
+                "address": "",
+                "port": 443,
+                "id": "", // Needs to match server side
+                "encryption": "none",
+                "flow": "xtls-rprx-vision"
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VLESS-TCP-XTLS-Vision/config_client.jsonc
+++ b/VLESS-TCP-XTLS-Vision/config_client.jsonc
@@ -54,19 +54,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "", // Address, domain name or IP of the server
-                        "port": 443, // Port, consistent with the server
-                        "users": [
-                            {
-                                "id": "", // User ID, consistent with the server
-                                "encryption": "none",
-                                "flow": "xtls-rprx-vision"
-                            }
-                        ]
-                    }
-                ]
+                "address": "", // Address, domain name or IP of the server
+                "port": 443, // Port, consistent with the server
+                "id": "", // User ID, consistent with the server
+                "encryption": "none",
+                "flow": "xtls-rprx-vision"
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VLESS-TCP/config_client.jsonc
+++ b/VLESS-TCP/config_client.jsonc
@@ -23,19 +23,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "1.2.3.4",
-                        "port": 1234,
-                        "users": [
-                            {
-                                "id": "",
-                                "encryption": "none",
-                                "level": 0
-                            }
-                        ]
-                    }
-                ]
+                "address": "1.2.3.4",
+                "port": 1234,
+                "id": "",
+                "encryption": "none",
+                "level": 0
             },
             "streamSettings": {
                 "network": "tcp"

--- a/VLESS-TLS-SplitHTTP-CaddyNginx/client.jsonc
+++ b/VLESS-TLS-SplitHTTP-CaddyNginx/client.jsonc
@@ -16,18 +16,10 @@
       {
         "protocol": "vless",
         "settings": {
-          "vnext": [
-            {
-              "address": "",
-              "port": 443,
-              "users": [
-                {
-                  "id": "",
-                  "encryption": "none"
-                }
-              ]
-            }
-          ]
+          "address": "",
+          "port": 443,
+          "id": "",
+          "encryption": "none"
         },
         "streamSettings": {
           "network": "splithttp",

--- a/VLESS-TLS-SplitHTTP-H3/client.jsonc
+++ b/VLESS-TLS-SplitHTTP-H3/client.jsonc
@@ -21,18 +21,10 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "example.com", // Change to your domain.
-                        "port": 443,
-                        "users": [
-                            {
-                                "id": "UUID", // Change to your UUID.
-                                "encryption": "none"
-                            }
-                        ]
-                    }
-                ]
+                "address": "example.com", // Change to your domain.
+                "port": 443,
+                "id": "UUID", // Change to your UUID.
+                "encryption": "none"
             },
             "streamSettings": {
                 "network": "splithttp",

--- a/VLESS-WSS-Nginx/client.jsonc
+++ b/VLESS-WSS-Nginx/client.jsonc
@@ -19,18 +19,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "xx.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "", //填写你的 UUID
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "xx.com",
+        "port": 443,
+        "id": "", //填写你的 UUID
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "ws",

--- a/VLESS-XHTTP-Reality/minimal-steal_others/client-bypass-cn.jsonc
+++ b/VLESS-XHTTP-Reality/minimal-steal_others/client-bypass-cn.jsonc
@@ -32,19 +32,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "", // 服务端的域名或 IP
-                        "port": 443, // 填入配置服务器入站时设定的监听端口
-                        "users": [
-                            {
-                                "id": "", // 与服务端一致
-                                "encryption": "none",
-                                "flow": ""
-                            }
-                        ]
-                    }
-                ]
+                "address": "", // 服务端的域名或 IP
+                "port": 443, // 填入配置服务器入站时设定的监听端口
+                "id": "", // 与服务端一致
+                "encryption": "none",
+                "flow": ""
             },
             "streamSettings": {
                 "network": "xhttp",

--- a/VLESS-XHTTP-Reality/minimal-steal_others/client.jsonc
+++ b/VLESS-XHTTP-Reality/minimal-steal_others/client.jsonc
@@ -20,19 +20,11 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "", // 服务端的域名或 IP
-                        "port": 443, // 填入配置服务器入站时设定的监听端口
-                        "users": [
-                            {
-                                "id": "", // 与服务端一致
-                                "encryption": "none",
-                                "flow": ""
-                            }
-                        ]
-                    }
-                ]
+                "address": "", // 服务端的域名或 IP
+                "port": 443, // 填入配置服务器入站时设定的监听端口
+                "id": "", // 与服务端一致
+                "encryption": "none",
+                "flow": ""
             },
             "streamSettings": {
                 "network": "xhttp",

--- a/VLESS-XHTTP3-Nginx/client.jsonc
+++ b/VLESS-XHTTP3-Nginx/client.jsonc
@@ -14,18 +14,10 @@
     {
       "protocol": "vless",
       "settings": {
-        "vnext": [
-          {
-            "address": "example.com",
-            "port": 443,
-            "users": [
-              {
-                "id": "", //填写你的 UUID
-                "encryption": "none"
-              }
-            ]
-          }
-        ]
+        "address": "example.com",
+        "port": 443,
+        "id": "", //填写你的 UUID
+        "encryption": "none"
       },
       "streamSettings": {
         "network": "xhttp",

--- a/VLESS-gRPC-REALITY/config_client.jsonc
+++ b/VLESS-gRPC-REALITY/config_client.jsonc
@@ -49,22 +49,13 @@
             "tag": "proxy",
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "1.2.3.4", // Server IPv4
-                        "port": 80,
-                        "users": [
-                            {
-                                "id": "drEwvgYhS15C",
-                                "alterId": 0,
-                                "email": "t@t.tt",
-                                "security": "auto",
-                                "encryption": "none",
-                                "flow": ""
-                            }
-                        ]
-                    }
-                ]
+                "address": "1.2.3.4", // Server IPv4
+                "port": 80,
+                "id": "drEwvgYhS15C",
+                "email": "t@t.tt",
+                "security": "auto",
+                "encryption": "none",
+                "flow": ""
             },
             "streamSettings": {
                 "network": "grpc",

--- a/VLESS-mKCPSeed/config_client.jsonc
+++ b/VLESS-mKCPSeed/config_client.jsonc
@@ -16,18 +16,10 @@
         {
             "protocol": "vless",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "{{ host }}",
-                        "port": {{ port }},
-                        "users": [
-                            {
-                                "id": "{{ uuid }}",
-                                "encryption": "none"
-                            }
-                        ]
-                    }
-                ]
+                "address": "{{ host }}",
+                "port": {{ port }},
+                "id": "{{ uuid }}",
+                "encryption": "none"
             },
             "streamSettings": {
                 "network": "kcp",

--- a/VMess-HTTP/config_client.jsonc
+++ b/VMess-HTTP/config_client.jsonc
@@ -34,17 +34,9 @@
         {
             "protocol": "vmess",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "",
-                        "port": 1234,
-                        "users": [
-                            {
-                                "id": ""
-                            }
-                        ]
-                    }
-                ]
+                "address": "",
+                "port": 1234,
+                "id": ""
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VMess-HTTP2/config_client.jsonc
+++ b/VMess-HTTP2/config_client.jsonc
@@ -34,18 +34,10 @@
         {
             "protocol": "vmess",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "",
-                        "port": 1234,
-                        "users": [
-                            {
-                                "id": "",
-                                "security": "none"
-                            }
-                        ]
-                    }
-                ]
+                "address": "",
+                "port": 1234,
+                "id": "",
+                "security": "none"
             },
             "streamSettings": {
                 "network": "http",

--- a/VMess-TCP-TLS/config_client.jsonc
+++ b/VMess-TCP-TLS/config_client.jsonc
@@ -34,18 +34,10 @@
         {
             "protocol": "vmess",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "",
-                        "port": 1234,
-                        "users": [
-                            {
-                                "id": "",
-                                "security": "none"
-                            }
-                        ]
-                    }
-                ]
+                "address": "",
+                "port": 1234,
+                "id": "",
+                "security": "none"
             },
             "streamSettings": {
                 "network": "tcp",

--- a/VMess-TCP/config_client.jsonc
+++ b/VMess-TCP/config_client.jsonc
@@ -34,17 +34,9 @@
         {
             "protocol": "vmess",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "",
-                        "port": 1234,
-                        "users": [
-                            {
-                                "id": ""
-                            }
-                        ]
-                    }
-                ]
+                "address": "",
+                "port": 1234,
+                "id": ""
             },
             "streamSettings": {
                 "network": "tcp"

--- a/VMess-Websocket-TLS/config_client.jsonc
+++ b/VMess-Websocket-TLS/config_client.jsonc
@@ -34,18 +34,10 @@
         {
             "protocol": "vmess",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "",
-                        "port": 1234,
-                        "users": [
-                            {
-                                "id": "",
-                                "security": "none"
-                            }
-                        ]
-                    }
-                ]
+                "address": "",
+                "port": 1234,
+                "id": "",
+                "security": "none"
             },
             "streamSettings": {
                 "network": "ws",

--- a/VMess-Websocket/config_client.jsonc
+++ b/VMess-Websocket/config_client.jsonc
@@ -34,17 +34,9 @@
         {
             "protocol": "vmess",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "",
-                        "port": 1234,
-                        "users": [
-                            {
-                                "id": ""
-                            }
-                        ]
-                    }
-                ]
+                "address": "",
+                "port": 1234,
+                "id": ""
             },
             "streamSettings": {
                 "network": "ws"

--- a/VMess-mKCPSeed/config_client.jsonc
+++ b/VMess-mKCPSeed/config_client.jsonc
@@ -16,17 +16,9 @@
         {
             "protocol": "vmess",
             "settings": {
-                "vnext": [
-                    {
-                        "address": "{{ host }}",
-                        "port": "{{ port }}",
-                        "users": [
-                            {
-                                "id": "{{ uuid }}"
-                            }
-                        ]
-                    }
-                ]
+                "address": "{{ host }}",
+                "port": "{{ port }}",
+                "id": "{{ uuid }}"
             },
             "streamSettings": {
                 "network": "kcp",


### PR DESCRIPTION
删除`vnext`块，把`address`, `port`, `id`等配置直接放进`OutboundConfigurationObject`。删除了Vmess的`alterId`配置。